### PR TITLE
#60 Update Task/Cake.ps1

### DIFF
--- a/Task/Cake.ps1
+++ b/Task/Cake.ps1
@@ -51,7 +51,7 @@ if (!(Test-Path $NuGetPath)) {
   $NuGetPath = Join-Path $ToolPath "nuget.exe";
 
   # If we haven't been given a custom nuget.exe download location then download the latest version from nuget.org.
-  if($null -eq $nugetExeDownloadLocation) {
+  if(-Not $nugetExeDownloadLocation) {
       $nugetExeDownloadLocation = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
   }
   Write-Verbose "Getting nuget.exe from $nugetExeDownloadLocation"


### PR DESCRIPTION
Fixes Bug to download nuget.exe. Powershell supports a check for null or empty in one check.

[Powershell Testing if string is null or empty](https://www.morgantechspace.com/2015/04/powershell-testing-if-string-is-null-or-empty.html)
